### PR TITLE
Remove https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is go CLI tool for send fast Multiple  get HTTP request.
 you can use this tool for findings xss and sql injection vulnerablity from multi URL.
 
 # How to Install?
-go get -u https://github.com/takshal/freq
+go get -u github.com/takshal/freq
 
 
 # smart Use


### PR DESCRIPTION
With https:// include it gives this error so remove https:// in installation docs


go get: malformed module path "https:/github.com/takshal/freq": invalid char ':'